### PR TITLE
Fix set() not clearing cached instance on override

### DIFF
--- a/src/DI/Container.php
+++ b/src/DI/Container.php
@@ -51,6 +51,7 @@ class Container implements ContainerInterface
     {
         $this->factories[$id] = $factory;
         $this->dependencies[$id] = $dependencies;
+        unset($this->concrete[$id]);
 
         return $this;
     }

--- a/tests/ContainerTest.php
+++ b/tests/ContainerTest.php
@@ -130,6 +130,16 @@ final class ContainerTest extends TestCase
         $this->assertSame('second', $container->get('foo'));
     }
 
+    public function testSetOverridesCachedInstance(): void
+    {
+        $container = new Container();
+        $container->set('foo', fn (): string => 'first', []);
+        $this->assertSame('first', $container->get('foo'));
+
+        $container->set('foo', fn (): string => 'second', []);
+        $this->assertSame('second', $container->get('foo'));
+    }
+
     public function testFactoryCanReturnNull(): void
     {
         $container = new Container();


### PR DESCRIPTION
## Summary
- When `set()` was called to override an already-resolved dependency, `get()` still returned the stale cached value from `$concrete`
- Added `unset($this->concrete[$id])` in `set()` to clear the cache when a dependency is re-registered
- Added test `testSetOverridesCachedInstance` that resolves a dependency, overrides it via `set()`, and verifies the new value is returned

## Test plan
- [x] All 31 existing tests pass
- [x] New test covers the resolve-then-override scenario